### PR TITLE
fix bin entrypoint; rename to scoped package for publication

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "opendocumenter",
+  "name": "@cspotcode/opendocumenter",
   "version": "0.5.0",
   "author": "$ourOpenCode",
   "scripts": {
@@ -44,7 +44,7 @@
     "serve": "^11.3.2"
   },
   "bin": {
-    "opendocumenter": "src/cli.js"
+    "opendocumenter": "src-engine/cli.js"
   },
   "engines": {
     "node": ">=14.6"


### PR DESCRIPTION
Moving change from cspotcode/OpenDocumenter to here for better docker packaging.